### PR TITLE
Fix for device deletion

### DIFF
--- a/src/docs/schemas/Event.ts
+++ b/src/docs/schemas/Event.ts
@@ -13,7 +13,8 @@ const event = {
     mediaId: {
       type: 'number',
       examples: [123, 678],
-      description: 'The ID of the media file - This can be used on the `/media/:id` route to retrive the media file'
+      description:
+        'The ID of the media file - This can be used on the `/media/:id` route to retrive the media file',
     },
     mediaUrl: {
       type: 'string',

--- a/src/routes/Routes.ts
+++ b/src/routes/Routes.ts
@@ -5,7 +5,7 @@ import DevicesController from './controllers/Devices/DevicesController';
 import EventsController from './controllers/Events/EventsController';
 import MediaController from './controllers/Media/MediaController';
 import TestController from './controllers/Test/TestController';
-import { LocalOnly } from '../utils/LocalOnly';
+import {LocalOnly} from '../utils/LocalOnly';
 
 export abstract class Routes {
   public static Register(): void {
@@ -15,4 +15,3 @@ export abstract class Routes {
     Server.App.use('/test', LocalOnly, TestController);
   }
 }
-

--- a/src/routes/controllers/Devices/AddDevice.ts
+++ b/src/routes/controllers/Devices/AddDevice.ts
@@ -112,7 +112,9 @@ export async function addDevice(
     hls_segment_duration: data.hlsSegmentDuration,
     hls_segment_size: data.hlsSegmentSize,
   }).then(async device => {
-    let d = await Devices.findOne({where: {device: device.dataValues.device}}); //-> Work around because sequalize nulls id
+    let d = await Devices.findOne({
+      where: {device: device.dataValues.device},
+    }); //-> Work around because sequalize nulls id
     res.status(200).send(
       new ErrorResponse(200, 'Created device sucessfully!', {
         deviceId: d.dataValues.id,

--- a/src/routes/controllers/Devices/DeleteDevice.ts
+++ b/src/routes/controllers/Devices/DeleteDevice.ts
@@ -11,10 +11,80 @@ export async function deleteDevice(
 ): Promise<void> {
   let deviceId = req.params.deviceId ?? -1;
 
-  Devices.findOne({where: {id: deviceId}})
-    .then(device => {
-      let id = device.dataValues.id || -1;
-      if (id == -1) {
+  let attempts = 10;
+  let shouldRetry = false;
+
+  //FIXME: Remove this retry loop. This same code is present in PHP due to the posibility of new Media being created while the device is being deleted.
+  do {
+    attempts--;
+    Devices.findOne({where: {id: deviceId}})
+      .then(device => {
+        let id = device.dataValues.id || -1;
+        if (id == -1) {
+          res
+            .status(404)
+            .send(
+              new ErrorResponse(
+                404,
+                `A device with the ID ${deviceId} was not found!`
+              )
+            );
+          return;
+        }
+        try {
+          Server.sequelize.query(
+            `DELETE FROM EventsCam WHERE device_id='${id}'`
+          );
+          Server.sequelize.query(
+            `DELETE FROM OnvifEvents WHERE device_id='${id}'`
+          );
+          Server.sequelize
+            .query(
+              `SELECT id, filepath FROM Media WHERE device_id='${id}' ORDER BY id DESC`
+            )
+            .then((result: [any, any]) => {
+              if (result[0].length > 0) {
+                let highestId = result[0][0].id;
+                result[0].forEach((media: any) => {
+                  fs.unlink(media.filepath, err => {
+                    if (err) {
+                      Server.Logs.error(
+                        `An error occured when deleting media belonging to ID ${deviceId} - ${err}`
+                      );
+                    }
+                  });
+                });
+                try {
+                  Server.sequelize.query(
+                    `DELETE FROM Media WHERE device_id='${id}' AND id <= ${highestId}`
+                  );
+                } catch (err) {
+                  shouldRetry = true;
+                }
+              }
+            });
+          device.destroy();
+          res
+            .status(200)
+            .send(new ErrorResponse(200, 'Deleted device sucessfully!'));
+          return;
+        } catch (err) {
+          shouldRetry = true;
+          Server.Logs.error(
+            `An error occured when deleting device of ID ${deviceId} - ${err}`
+          );
+          res
+            .status(500)
+            .send(
+              new ErrorResponse(
+                500,
+                `An error occured when deleting device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
+              )
+            );
+          return;
+        }
+      })
+      .catch(err => {
         res
           .status(404)
           .send(
@@ -24,62 +94,17 @@ export async function deleteDevice(
             )
           );
         return;
-      }
-      try {
-        Server.sequelize.query(`DELETE FROM EventsCam WHERE device_id='${id}'`);
-        Server.sequelize.query(
-          `DELETE FROM OnvifEvents WHERE device_id='${id}'`
-        );
-        Server.sequelize
-          .query(
-            `SELECT id, filepath FROM Media WHERE device_id='${id}' ORDER BY id DESC`
-          )
-          .then((result: [any, any]) => {
-            if (result[0].length > 0) {
-              let highestId = result[0][0].id;
-              result[0].forEach((media: any) => {
-                fs.unlink(media.filepath, err => {
-                  if (err) {
-                    Server.Logs.error(
-                      `An error occured when deleting media belonging to ID ${deviceId} - ${err}`
-                    );
-                  }
-                });
-              });
-              Server.sequelize.query(
-                `DELETE FROM Media WHERE device_id='${id}' AND id <= ${highestId}`
-              );
-            }
-          });
-        device.destroy();
-        res
-          .status(200)
-          .send(new ErrorResponse(200, 'Deleted device sucessfully!'));
-        return;
-      } catch (err) {
-        Server.Logs.error(
-          `An error occured when deleting device of ID ${deviceId} - ${err}`
-        );
-        res
-          .status(500)
-          .send(
-            new ErrorResponse(
-              500,
-              `An error occured when deleting device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
-            )
-          );
-        return;
-      }
-    })
-    .catch(err => {
-      res
-        .status(404)
-        .send(
-          new ErrorResponse(
-            404,
-            `A device with the ID ${deviceId} was not found!`
-          )
-        );
-      return;
-    });
+      });
+  } while (shouldRetry && attempts > 0);
+
+  if (attempts == 0 && shouldRetry) {
+    res
+      .status(500)
+      .send(
+        new ErrorResponse(
+          500,
+          `Failed to deleted the device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
+        )
+      );
+  }
 }

--- a/src/routes/controllers/Devices/DeleteDevice.ts
+++ b/src/routes/controllers/Devices/DeleteDevice.ts
@@ -11,80 +11,10 @@ export async function deleteDevice(
 ): Promise<void> {
   let deviceId = req.params.deviceId ?? -1;
 
-  let attempts = 10;
-  let shouldRetry = false;
-
-  //FIXME: Remove this retry loop. This same code is present in PHP due to the posibility of new Media being created while the device is being deleted.
-  do {
-    attempts--;
-    Devices.findOne({where: {id: deviceId}})
-      .then(device => {
-        let id = device.dataValues.id || -1;
-        if (id == -1) {
-          res
-            .status(404)
-            .send(
-              new ErrorResponse(
-                404,
-                `A device with the ID ${deviceId} was not found!`
-              )
-            );
-          return;
-        }
-        try {
-          Server.sequelize.query(
-            `DELETE FROM EventsCam WHERE device_id='${id}'`
-          );
-          Server.sequelize.query(
-            `DELETE FROM OnvifEvents WHERE device_id='${id}'`
-          );
-          Server.sequelize
-            .query(
-              `SELECT id, filepath FROM Media WHERE device_id='${id}' ORDER BY id DESC`
-            )
-            .then((result: [any, any]) => {
-              if (result[0].length > 0) {
-                let highestId = result[0][0].id;
-                result[0].forEach((media: any) => {
-                  fs.unlink(media.filepath, err => {
-                    if (err) {
-                      Server.Logs.error(
-                        `An error occured when deleting media belonging to ID ${deviceId} - ${err}`
-                      );
-                    }
-                  });
-                });
-                try {
-                  Server.sequelize.query(
-                    `DELETE FROM Media WHERE device_id='${id}' AND id <= ${highestId}`
-                  );
-                } catch (err) {
-                  shouldRetry = true;
-                }
-              }
-            });
-          device.destroy();
-          res
-            .status(200)
-            .send(new ErrorResponse(200, 'Deleted device sucessfully!'));
-          return;
-        } catch (err) {
-          shouldRetry = true;
-          Server.Logs.error(
-            `An error occured when deleting device of ID ${deviceId} - ${err}`
-          );
-          res
-            .status(500)
-            .send(
-              new ErrorResponse(
-                500,
-                `An error occured when deleting device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
-              )
-            );
-          return;
-        }
-      })
-      .catch(err => {
+  Devices.findOne({where: {id: deviceId}})
+    .then(device => {
+      let id = device.dataValues.id || -1;
+      if (id == -1) {
         res
           .status(404)
           .send(
@@ -94,17 +24,85 @@ export async function deleteDevice(
             )
           );
         return;
-      });
-  } while (shouldRetry && attempts > 0);
-
-  if (attempts == 0 && shouldRetry) {
-    res
-      .status(500)
-      .send(
-        new ErrorResponse(
-          500,
-          `Failed to deleted the device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
-        )
-      );
-  }
+      }
+      try {
+        Server.sequelize
+          .query(`DELETE FROM EventsCam WHERE device_id='${id}'`)
+          .then(() => {
+            Server.sequelize
+              .query(`DELETE FROM OnvifEvents WHERE device_id='${id}'`)
+              .then(() => {
+                Server.sequelize
+                  .query(
+                    `SELECT id, filepath FROM Media WHERE device_id='${id}' ORDER BY id DESC`
+                  )
+                  .then((result: [any, any]) => {
+                    if (result[0].length > 0) {
+                      let highestId = result[0][0].id;
+                      result[0].forEach((media: any) => {
+                        fs.unlink(media.filepath, err => {
+                          if (err) {
+                            Server.Logs.error(
+                              `An error occured when deleting media belonging to ID ${deviceId} - ${err}`
+                            );
+                          }
+                        });
+                      });
+                      try {
+                        Server.sequelize
+                          .query(
+                            `DELETE FROM Media WHERE device_id='${id}' AND id <= ${highestId}`
+                          )
+                          .then(() => {
+                            device.destroy();
+                            res
+                              .status(200)
+                              .send(
+                                new ErrorResponse(
+                                  200,
+                                  'Deleted device sucessfully!'
+                                )
+                              );
+                            return;
+                          });
+                      } catch (err) {
+                        res
+                          .status(500)
+                          .send(
+                            new ErrorResponse(
+                              500,
+                              `Failed to deleted the device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
+                            )
+                          );
+                      }
+                    }
+                  });
+              });
+          });
+      } catch (err) {
+        Server.Logs.error(
+          `An error occured when deleting device of ID ${deviceId} - ${err}`
+        );
+        res
+          .status(500)
+          .send(
+            new ErrorResponse(
+              500,
+              `An error occured when deleting device of ID ${deviceId}! Please report this to the Bluecherry team along with logs`
+            )
+          );
+        return;
+      }
+    })
+    .catch(err => {
+      res
+        .status(404)
+        .send(
+          new ErrorResponse(
+            404,
+            `A device with the ID ${deviceId} was not found!`
+          )
+        );
+      return;
+    });
 }

--- a/src/routes/controllers/Devices/UpdateDevice.ts
+++ b/src/routes/controllers/Devices/UpdateDevice.ts
@@ -53,7 +53,7 @@ export async function updateDevice(
     substreamPath: poppedSubstream[2],
     mjpegPort: poppedMjpegPath[1],
     mjpegPath: poppedMjpegPath[2],
-    protocol: originalDevice.dataValues.protocol
+    protocol: originalDevice.dataValues.protocol,
   };
 
   //-> Check if name exists
@@ -77,7 +77,6 @@ export async function updateDevice(
   }
 
   if ('protocol' in data || 'substreamPath' in data) {
-
     let protocol = data.protocol ?? oldProps.protocol;
 
     //-> Protocol Check
@@ -120,7 +119,10 @@ export async function updateDevice(
     }
   }
 
-  let audioDisabled = ('audioEnabled'in data) ? !data.audioEnabled  : originalDevice.dataValues.audio_enabled;
+  let audioDisabled =
+    'audioEnabled' in data
+      ? !data.audioEnabled
+      : originalDevice.dataValues.audio_enabled;
 
   //-> Update device
   Devices.update(
@@ -191,6 +193,10 @@ export async function updateDevice(
     },
     {where: {id: deviceId}}
   ).then(async () => {
-    res.status(200).send(new ErrorResponse(200, 'Updated device sucessfully!', { updatedBody: data }));
+    res.status(200).send(
+      new ErrorResponse(200, 'Updated device sucessfully!', {
+        updatedBody: data,
+      })
+    );
   });
 }

--- a/src/routes/controllers/Test/EventTests.ts
+++ b/src/routes/controllers/Test/EventTests.ts
@@ -13,30 +13,26 @@ export async function createEventTests(
     Events.bulkCreate(req.body.events)
       .then(eventsArray => {
         Server.sequelize.query(`SET FOREIGN_KEY_CHECKS = 1`).then(() => {
-          Events.findAll({where: {time: {[Op.lte]: 930317922}}}).then(
-            eventBodys => {
-              let events = eventBodys
-                .sort((a, b) => a.dataValues.time - b.dataValues.time)
-                .map(e => e.dataValues);
-              res
-                .status(200)
-                .json({
-                  message: 'Successfully created test data!',
-                  data: events,
-                });
-            }
-          );
+          Events.findAll({
+            where: {time: {[Op.lte]: 930317922}},
+          }).then(eventBodys => {
+            let events = eventBodys
+              .sort((a, b) => a.dataValues.time - b.dataValues.time)
+              .map(e => e.dataValues);
+            res.status(200).json({
+              message: 'Successfully created test data!',
+              data: events,
+            });
+          });
         });
       })
       .catch(err => {
         Server.sequelize.query(`SET FOREIGN_KEY_CHECKS = 1`).then(() => {
-          res
-            .status(500)
-            .json(
-              new ErrorResponse(500, 'An error occured creating test data!', {
-                error: err,
-              })
-            );
+          res.status(500).json(
+            new ErrorResponse(500, 'An error occured creating test data!', {
+              error: err,
+            })
+          );
           Server.Logs.error('An error occured creating test data - ' + err);
         });
       });
@@ -54,12 +50,10 @@ export async function deleteEventTests(
       res.status(200).json({message: 'Successfully deleted test data!'});
     })
     .catch(err => {
-      res
-        .status(500)
-        .json(
-          new ErrorResponse(500, 'An error occured deleting test data!', {
-            error: err,
-          })
-        );
+      res.status(500).json(
+        new ErrorResponse(500, 'An error occured deleting test data!', {
+          error: err,
+        })
+      );
     });
 }

--- a/src/utils/LocalOnly.ts
+++ b/src/utils/LocalOnly.ts
@@ -7,10 +7,8 @@ export function LocalOnly(
   res: Response,
   next: NextFunction
 ): void {
-  Server.Logs.trace("Local only connection attempt from: " + req.ip)
-    if(req.ip.includes(process.env.BC_HOST)) {
-        next();
-    }
-    else
-        res.status(401).send('Route not allowed on this connection!');
+  Server.Logs.trace('Local only connection attempt from: ' + req.ip);
+  if (req.ip.includes(process.env.BC_HOST)) {
+    next();
+  } else res.status(401).send('Route not allowed on this connection!');
 }

--- a/test/media.spec.ts
+++ b/test/media.spec.ts
@@ -8,9 +8,11 @@ const axios = Axios.create({
 
 describe('Reading Media', () => {
   test('GET /media/ with media id', async () => {
-        const event = (await axios.get('/events')).data.events[0];
-        const res = await axios.get(`/media/${event.mediaId}`)
-        expect(res.status).toBe(200);
-        expect(Number(res.headers['content-duration'].replaceAll(":", ""))).toBeGreaterThan(0);
+    const event = (await axios.get('/events')).data.events[0];
+    const res = await axios.get(`/media/${event.mediaId}`);
+    expect(res.status).toBe(200);
+    expect(
+      Number(res.headers['content-duration'].replaceAll(':', ''))
+    ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
This PR contains a change in structure for the `DELETE /devices/{id}` route.

Despite it passing tests, it presented some issues on some Bluecherry deployments. With the help of DTV, the approach was changed to a promise chain, this will ensure that the records in the database are properly disposed of before moving to delete the main device record.

Along side this fix, there are minor spelling corrections and code formatting tweaks.